### PR TITLE
Fix for bug #68739?

### DIFF
--- a/filters/mbfilter_sjis_2004.c
+++ b/filters/mbfilter_sjis_2004.c
@@ -672,6 +672,8 @@ retry:
 			CK(mbfl_filt_conv_illegal_output(c, filter));
 		}
 	}
+
+	return c;
 }
 
 int


### PR DESCRIPTION
I'm not sure if this patch is correct. This patch is for

https://bugs.php.net/bug.php?id=68738

mbfl_filt_conv_wchar_jis2004() seems to return -1 for invalid, so
I just assumed that c is ok at the end.